### PR TITLE
Implement Prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ docker-build:
 .PHONY: docker-run-benchmark
 docker-run-benchmark:
 	docker run -p ${PORT}:${PORT} ${DOCKER_IMAGE_NANE} benchmark --port=${PORT}
+
+.PHONY: docker-compose-up
+docker-compose-up:
+	docker-compose -f ./build/docker-compose.yml up -d
+
+.PHONY: docker-compose-down
+docker-compose-down:
+	docker-compose -f ./build/docker-compose.yml down
 ##########
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINARY_NAME=pulse
 DOCKER_IMAGE_NANE=pulse
 CONFIG_DIR=./configs
 CONFIG_FILE=config.yaml
+PORT=8080
 
 .PHONY: build
 build:
@@ -22,6 +23,10 @@ run-analyzer: build
 .PHONY: docker-build
 docker-build:
 	docker build -t ${DOCKER_IMAGE_NANE} -f build/Dockerfile .
+
+.PHONY: docker-run-benchmark
+docker-run-benchmark:
+	docker run -p ${PORT}:${PORT} ${DOCKER_IMAGE_NANE} benchmark --port=${PORT}
 ##########
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Docker
 ```bash
-docker run ghcr.io/ssvlabsinfra/ssv-pulse:latest benchmark --consensus-addr=REPLACE_WITH_ADDR --execution-addr=REPLACE_WITH_ADDR --ssv-addr=REPLACE_WITH_ADDR
+docker run ghcr.io/ssvlabs/ssv-pulse:latest benchmark --consensus-addr=REPLACE_WITH_ADDR --execution-addr=REPLACE_WITH_ADDR --ssv-addr=REPLACE_WITH_ADDR
 ```
 
 # Description

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################
-FROM --platform=$BUILDPLATFORM golang:1.23@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825c54fb862cd AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e AS builder
 
 WORKDIR /app
 

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  ### MONITORING
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    depends_on:
+      - ssv-pulse
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - prometheus
+
+  ### SERVICES
+  ssv-pulse:
+    container_name: ssv-pulse
+    build:
+      dockerfile: ./build/Dockerfile
+      context: .. 
+    ports:
+      - "8080:8080" 
+    command: ["benchmark"]
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/build/grafana/provisioning/dashboards/dashboards.yml
+++ b/build/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/build/grafana/provisioning/dashboards/pulse.json
+++ b/build/grafana/provisioning/dashboards/pulse.json
@@ -1,0 +1,784 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 6,
+        "panels": [],
+        "title": "Consensus Client",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 1
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "histogram_quantile(0.95, sum(rate(pulse_consensus_latency_bucket[$__rate_interval])) by (le))",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "latency",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Consensus Latency Seconds",
+        "type": "histogram"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 1
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_peer_count",
+            "instant": false,
+            "legendFormat": "consensus peers",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Consensus Peers",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 9
+        },
+        "id": 8,
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true,
+            "values": [
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_received_blocks",
+            "instant": false,
+            "legendFormat": "received blocks",
+            "range": true,
+            "refId": "Received Blocks"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_missed_blocks",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "missed blocks",
+            "range": true,
+            "refId": "Missed Blocks"
+          }
+        ],
+        "title": "Consensus Blocks",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "fieldMinMax": false,
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percent"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 9
+        },
+        "id": 11,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_correctness",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Attestation Correctness",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 9
+        },
+        "id": 10,
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true,
+            "values": [
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_fresh_attestations",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "fresh attestations",
+            "range": true,
+            "refId": "Fresh Attestations"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_consensus_missed_attestations",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "missed attestations",
+            "range": true,
+            "refId": "Missed Attestations"
+          }
+        ],
+        "title": "Consensus Attestations",
+        "type": "piechart"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 4,
+        "panels": [],
+        "title": "Execution Client",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 17
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_execution_peer_count",
+            "instant": false,
+            "legendFormat": "peer count",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Execution Peers",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 25
+        },
+        "id": 2,
+        "panels": [],
+        "title": "SSV Client",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 26
+        },
+        "id": 3,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "expr": "pulse_ssv_connections_count",
+            "instant": false,
+            "legendFormat": "{{direction}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "SSV Connections",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "default": true,
+          "type": "prometheus",
+          "uid": "prometheusdatasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 26
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.2.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheusdatasource"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "pulse_ssv_peer_count",
+            "instant": false,
+            "legendFormat": "peer count",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "SSV Peers",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "SSV Pulse",
+    "uid": "ddxd6vn0gq5tsb",
+    "version": 16,
+    "weekStart": ""
+  }

--- a/build/grafana/provisioning/datasources/datasources.yml
+++ b/build/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    uid: prometheusdatasource

--- a/build/prometheus/prometheus.yml
+++ b/build/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'ssv-pulse-scraper'
+    static_configs:
+      - targets: ['ssv-pulse:8080']

--- a/configs/benchmark.go
+++ b/configs/benchmark.go
@@ -51,11 +51,16 @@ type Infrastructure struct {
 	Metrics InfrastructureMetrics `mapstructure:"metrics"`
 }
 
+type Server struct {
+	Port uint16 `mapstructure:"port"`
+}
+
 type Benchmark struct {
 	Consensus      Consensus      `mapstructure:"consensus"`
 	Execution      Execution      `mapstructure:"execution"`
 	SSV            SSV            `mapstructure:"ssv"`
 	Infrastructure Infrastructure `mapstructure:"infrastructure"`
+	Server         Server         `mapstructure:"server"`
 	Duration       time.Duration  `mapstructure:"duration"`
 	Network        string         `mapstructure:"network"`
 }

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,6 +1,9 @@
 benchmark:
   duration: 15m
   network: mainnet
+  server:
+    port: 8080
+
   consensus:
     address: 
     metrics: 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aquasecurity/table v1.8.0
 	github.com/grafana/loki-client-go v0.0.0-20230116142646-e7494d0ef70c
 	github.com/mackerelio/go-osstat v0.2.5
+	github.com/prometheus/client_golang v1.20.0
 	github.com/prometheus/common v0.57.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
@@ -34,6 +35,7 @@ require (
 	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -45,7 +47,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pk910/dynamic-ssz v0.0.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.20.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/prometheus v0.35.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ssvlabsinfra/ssv-pulse
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/aquasecurity/table v1.8.0

--- a/internal/benchmark/cmd.go
+++ b/internal/benchmark/cmd.go
@@ -53,7 +53,15 @@ var CMD = &cobra.Command{
 	Use:   "benchmark",
 	Short: "Run benchmarks of ssv node",
 	Run: func(cobraCMD *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), configs.Values.Benchmark.Duration)
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+		if configs.Values.Benchmark.Duration == 0 {
+			ctx, cancel = context.WithCancel(context.Background())
+		} else {
+			ctx, cancel = context.WithTimeout(context.Background(), configs.Values.Benchmark.Duration)
+		}
 
 		isValid, err := configs.Values.Benchmark.Validate()
 		if !isValid {

--- a/internal/benchmark/metrics/consensus/attestation.go
+++ b/internal/benchmark/metrics/consensus/attestation.go
@@ -198,6 +198,8 @@ func (a *AttestationMetric) calculateMeasurements(slot phase0.Slot) {
 			MissedBlockMeasurement: 1,
 		})
 
+		missedBlocksMetric.Inc()
+
 		logger.WriteMetric(metric.ConsensusGroup, a.Name, map[string]any{
 			MissedBlockMeasurement: 1,
 		})
@@ -210,6 +212,9 @@ func (a *AttestationMetric) calculateMeasurements(slot phase0.Slot) {
 			MissedAttestationMeasurement: 1,
 			ReceivedBlockMeasurement:     1,
 		})
+
+		missedAttestationsMetric.Inc()
+		receivedBlocksMetric.Inc()
 
 		logger.WriteMetric(metric.ConsensusGroup, a.Name, map[string]any{
 			MissedAttestationMeasurement: 1,
@@ -226,6 +231,9 @@ func (a *AttestationMetric) calculateMeasurements(slot phase0.Slot) {
 			FreshAttestationMeasurement: 1,
 			ReceivedBlockMeasurement:    1,
 		})
+
+		freshAttestationsMetric.Inc()
+		receivedBlocksMetric.Inc()
 
 		logger.WriteMetric(metric.ConsensusGroup, a.Name, map[string]any{
 			FreshAttestationMeasurement: 1,
@@ -249,6 +257,8 @@ func (a *AttestationMetric) calculateCorrectness() {
 	a.AddDataPoint(map[string]float64{
 		CorrectnessMeasurement: correctness,
 	})
+
+	correctnessMetric.Set(correctness)
 
 	logger.WriteMetric(metric.ConsensusGroup, a.Name, map[string]any{
 		CorrectnessMeasurement: correctness,

--- a/internal/benchmark/metrics/consensus/latency.go
+++ b/internal/benchmark/metrics/consensus/latency.go
@@ -77,6 +77,10 @@ func (l *LatencyMetric) measure(ctx context.Context) {
 
 	l.durations = append(l.durations, latency)
 
+	l.writeMetric(latency)
+}
+
+func (l *LatencyMetric) writeMetric(latency time.Duration) {
 	percentiles := metric.CalculatePercentiles(l.durations, 0, 10, 50, 90, 100)
 
 	l.AddDataPoint(map[string]time.Duration{
@@ -86,6 +90,8 @@ func (l *LatencyMetric) measure(ctx context.Context) {
 		DurationP90Measurement: percentiles[90],
 		DurationMaxMeasurement: percentiles[100],
 	})
+
+	latencyMetric.Observe(latency.Seconds())
 
 	logger.WriteMetric(metric.ConsensusGroup, l.Name, map[string]any{
 		DurationMinMeasurement: percentiles[0],

--- a/internal/benchmark/metrics/consensus/peers.go
+++ b/internal/benchmark/metrics/consensus/peers.go
@@ -106,9 +106,15 @@ func (p *PeerMetric) measure(ctx context.Context) {
 		return
 	}
 
+	p.writeMetric(peerNr)
+}
+
+func (p *PeerMetric) writeMetric(peerNr int) {
 	p.AddDataPoint(map[string]uint32{
 		PeerCountMeasurement: uint32(peerNr),
 	})
+
+	peerCountMetric.Set(float64(peerNr))
 
 	logger.WriteMetric(metric.ConsensusGroup, p.Name, map[string]any{PeerCountMeasurement: peerNr})
 }

--- a/internal/benchmark/metrics/consensus/prometheus.go
+++ b/internal/benchmark/metrics/consensus/prometheus.go
@@ -1,0 +1,69 @@
+package consensus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace = "pulse"
+	subsystem = "consensus"
+)
+
+var (
+	peerCountMetric = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name:      "peer_count",
+			Help:      "number of peers",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	latencyMetric = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "latency",
+		Help:      "histogram of latencies for HTTP requests in seconds",
+		Buckets:   prometheus.DefBuckets,
+		Namespace: namespace,
+		Subsystem: subsystem,
+	})
+
+	missedBlocksMetric = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name:      "missed_blocks",
+			Help:      "missed blocks",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	receivedBlocksMetric = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name:      "received_blocks",
+			Help:      "received blocks",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	missedAttestationsMetric = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name:      "missed_attestations",
+			Help:      "missed attestations",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	freshAttestationsMetric = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name:      "fresh_attestations",
+			Help:      "fresh attestations",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	correctnessMetric = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name:      "correctness",
+			Help:      "attestation correctness based on number of received blocks and attestations",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+)

--- a/internal/benchmark/metrics/execution/prometheus.go
+++ b/internal/benchmark/metrics/execution/prometheus.go
@@ -1,0 +1,21 @@
+package execution
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace = "pulse"
+	subsystem = "execution"
+)
+
+var (
+	peerCountMetric = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name:      "peer_count",
+			Help:      "number of peers",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+)

--- a/internal/benchmark/metrics/infrastructure/cpu.go
+++ b/internal/benchmark/metrics/infrastructure/cpu.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mackerelio/go-osstat/cpu"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/ssvlabsinfra/ssv-pulse/internal/platform/logger"
 	"github.com/ssvlabsinfra/ssv-pulse/internal/platform/metric"
 )
@@ -60,10 +61,17 @@ func (c *CPUMetric) measure() {
 	c.prevSystem = cpu.System
 	c.total = cpu.Total
 
+	c.writeMetric(systemPercent, userPercent)
+}
+
+func (c *CPUMetric) writeMetric(systemPercent, userPercent float64) {
 	c.AddDataPoint(map[string]float64{
 		SystemCPUMeasurement: systemPercent,
 		UserCPUMeasurement:   userPercent,
 	})
+
+	cpuUsageMetric.With(prometheus.Labels{cpuUsageTypeLabel: "system"}).Set(float64(systemPercent))
+	cpuUsageMetric.With(prometheus.Labels{cpuUsageTypeLabel: "user"}).Set(float64(userPercent))
 
 	logger.WriteMetric(metric.InfrastructureGroup, c.Name, map[string]any{
 		SystemCPUMeasurement: systemPercent,

--- a/internal/benchmark/metrics/infrastructure/prometheus.go
+++ b/internal/benchmark/metrics/infrastructure/prometheus.go
@@ -1,0 +1,31 @@
+package infrastructure
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace            = "pulse"
+	subsystem            = "infrastructure"
+	memoryUsageTypeLabel = "type"
+	cpuUsageTypeLabel    = "type"
+)
+
+var (
+	memoryUsageMetric = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "memory_usage",
+			Help:      "memory usage",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}, []string{memoryUsageTypeLabel})
+
+	cpuUsageMetric = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "cpu_usage",
+			Help:      "cpu usage",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}, []string{cpuUsageTypeLabel})
+)

--- a/internal/benchmark/metrics/ssv/prometheus.go
+++ b/internal/benchmark/metrics/ssv/prometheus.go
@@ -1,0 +1,30 @@
+package ssv
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace                = "pulse"
+	subsystem                = "ssv"
+	connectionDirectionLabel = "direction"
+)
+
+var (
+	peerCountMetric = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name:      "peer_count",
+			Help:      "number of peers",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		})
+
+	connectionsMetric = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "connections_count",
+			Help:      "number of connection",
+			Namespace: namespace,
+			Subsystem: subsystem,
+		}, []string{connectionDirectionLabel})
+)

--- a/internal/platform/server/host/host.go
+++ b/internal/platform/server/host/host.go
@@ -1,0 +1,37 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+const hostName = "0.0.0.0"
+
+type WebHost struct {
+	server http.Server
+}
+
+func New(port uint16, handler http.Handler) *WebHost {
+	return &WebHost{
+		server: http.Server{
+			Addr:    fmt.Sprintf("%s:%d", hostName, port),
+			Handler: handler,
+		},
+	}
+}
+
+func (h *WebHost) Run() {
+	go func() {
+		if err := h.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			const errMsg = "error running web host"
+			slog.With("error", err.Error()).Error(errMsg)
+			panic(errMsg)
+		}
+	}()
+}
+
+func (h *WebHost) Terminate(ctx context.Context) error {
+	return h.server.Shutdown(ctx)
+}

--- a/internal/platform/server/route/router.go
+++ b/internal/platform/server/route/router.go
@@ -1,0 +1,27 @@
+package route
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Router struct {
+	router *http.ServeMux
+}
+
+func NewRouter() *Router {
+	router := http.NewServeMux()
+	return &Router{
+		router: router,
+	}
+}
+
+func (r *Router) WithMetrics() *Router {
+	r.router.Handle("/metrics", promhttp.Handler())
+	return r
+}
+
+func (r *Router) Router() *http.ServeMux {
+	return r.router
+}


### PR DESCRIPTION
Changes:
- Implement Prometheus metrics with `/metrics` endpoint
- Add Grafana and Prometheus configurations (`/build` directory)
- Add dashboard configuration file
- Implement option to run the benchmark tool infinitely if `duration` config is to 0
- Bump Go to 1.23.1
- Add Makefile targets for docker compose