### PR TITLE
Better error handling for 'Peers' metric in all groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ssvlabs/ssv-pulse
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/aquasecurity/table v1.8.0

--- a/internal/benchmark/metrics/consensus/peers.go
+++ b/internal/benchmark/metrics/consensus/peers.go
@@ -3,7 +3,9 @@ package consensus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -78,14 +80,7 @@ func (p *PeerMetric) measure(ctx context.Context) {
 		p.AddDataPoint(map[string]uint32{
 			PeerCountMeasurement: 0,
 		})
-
-		var errorResponse any
-		_ = json.NewDecoder(res.Body).Decode(&errorResponse)
-		jsonErrResponse, _ := json.Marshal(errorResponse)
-		logger.WriteError(
-			metric.ConsensusGroup,
-			p.Name,
-			fmt.Errorf("received unsuccessful status code. Code: '%s'. Response: '%s'", res.Status, jsonErrResponse))
+		p.logErrorResponse(res)
 		return
 	}
 
@@ -107,6 +102,44 @@ func (p *PeerMetric) measure(ctx context.Context) {
 	}
 
 	p.writeMetric(peerNr)
+}
+
+func (p *PeerMetric) logErrorResponse(res *http.Response) {
+	var responseString string
+	if res.Header.Get("Content-Type") == "application/json" {
+		var errorResponse any
+		if err := json.NewDecoder(res.Body).Decode(&errorResponse); err != nil {
+			logger.WriteError(
+				metric.ConsensusGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to JSON decode response", res.Status)))
+			return
+		}
+		jsonErrResponse, err := json.Marshal(errorResponse)
+		if err != nil {
+			logger.WriteError(
+				metric.ConsensusGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to marshal response", res.Status)))
+			return
+		}
+		responseString = string(jsonErrResponse)
+	} else {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			logger.WriteError(
+				metric.ConsensusGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to decode response", res.Status)))
+			return
+		}
+		responseString = string(body)
+	}
+
+	logger.WriteError(
+		metric.ConsensusGroup,
+		p.Name,
+		fmt.Errorf("received unsuccessful status code. Code: '%s'. Response: '%s'", res.Status, responseString))
 }
 
 func (p *PeerMetric) writeMetric(peerNr int) {

--- a/internal/benchmark/metrics/ssv/peers.go
+++ b/internal/benchmark/metrics/ssv/peers.go
@@ -3,7 +3,9 @@ package ssv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -73,14 +75,7 @@ func (p *PeerMetric) measure(ctx context.Context) {
 
 	if res.StatusCode != http.StatusOK {
 		p.writeMetric(0)
-
-		var errorResponse any
-		_ = json.NewDecoder(res.Body).Decode(&errorResponse)
-		jsonErrResponse, _ := json.Marshal(errorResponse)
-		logger.WriteError(
-			metric.SSVGroup,
-			p.Name,
-			fmt.Errorf("received unsuccessful status code. Code: '%s'. Response: '%s'", res.Status, jsonErrResponse))
+		p.logErrorResponse(res)
 		return
 	}
 
@@ -91,6 +86,44 @@ func (p *PeerMetric) measure(ctx context.Context) {
 	}
 
 	p.writeMetric(resp.Advanced.Peers)
+}
+
+func (p *PeerMetric) logErrorResponse(res *http.Response) {
+	var responseString string
+	if res.Header.Get("Content-Type") == "application/json" {
+		var errorResponse any
+		if err := json.NewDecoder(res.Body).Decode(&errorResponse); err != nil {
+			logger.WriteError(
+				metric.SSVGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to JSON decode response", res.Status)))
+			return
+		}
+		jsonErrResponse, err := json.Marshal(errorResponse)
+		if err != nil {
+			logger.WriteError(
+				metric.SSVGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to marshal response", res.Status)))
+			return
+		}
+		responseString = string(jsonErrResponse)
+	} else {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			logger.WriteError(
+				metric.SSVGroup,
+				p.Name,
+				errors.Join(err, fmt.Errorf("received unsuccessful status code. Code: '%s'. Failed to decode response", res.Status)))
+			return
+		}
+		responseString = string(body)
+	}
+
+	logger.WriteError(
+		metric.SSVGroup,
+		p.Name,
+		fmt.Errorf("received unsuccessful status code. Code: '%s'. Response: '%s'", res.Status, responseString))
 }
 
 func (p *PeerMetric) writeMetric(value uint32) {


### PR DESCRIPTION
**Background**:

In some scenarios, we encountered error responses in the “Peers” metric, but the error logs did not specify the issue. There were two problems:

- Not handling the deserialization (unmarshalling) error correctly
- Not checking the response content type, instead assuming it was a JSON response

This implementation addresses the issue and improves the handling of such errors.

**Other**:

I know the code is not very DRY, but my gut feeling tells me it’s too early for abstraction. In the long term, if we have more metrics with similar scenarios where we need to use the HTTP client extensively, we should build a custom HTTP client wrapper centrally and reuse it across all HTTP-based metrics.