### PR TITLE
Increase the buffer size of the file reader

### DIFF
--- a/internal/analyzer/parser/client/service.go
+++ b/internal/analyzer/parser/client/service.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	attestationMsg = "starting QBFT instance"
+
+	parserName = "client"
 )
 
 type (
@@ -86,7 +88,12 @@ func (s *Service) Analyze() (Stats, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", s.logFile.Name()).
+			Error("error reading log file")
+
 		return stats, err
 	}
 

--- a/internal/analyzer/parser/commit/service.go
+++ b/internal/analyzer/parser/commit/service.go
@@ -15,6 +15,8 @@ import (
 const (
 	proposeMsg = "leader broadcasting proposal message"
 	commitMsg  = "got commit message"
+
+	parserName = "commit"
 )
 
 type (
@@ -74,7 +76,12 @@ func (s *Service) Analyze() (map[parser.SignerID]Stats, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", s.logFile.Name()).
+			Error("error reading log file")
+
 		return nil, err
 	}
 

--- a/internal/analyzer/parser/consensus/service.go
+++ b/internal/analyzer/parser/consensus/service.go
@@ -16,6 +16,8 @@ import (
 const (
 	partialSignatureLogRecord      = "🧩 reconstructed partial signatures"
 	attestationSubmissionLogRecord = "✅ successfully submitted attestation"
+
+	parserName = "consensus"
 )
 
 type (
@@ -103,8 +105,11 @@ func (s *Service) Analyze() (map[parser.SignerID]Stats, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
-		return stats, err
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", s.logFile.Name()).
+			Error("error reading log file")
 	}
 
 	signerConsensusTimes := make(map[parser.SignerID][]time.Duration)

--- a/internal/analyzer/parser/operator/service.go
+++ b/internal/analyzer/parser/operator/service.go
@@ -17,6 +17,8 @@ import (
 const (
 	proposalMsg      = "📢 got proposal, broadcasting prepare message"
 	savedInstanceMsg = "💾 saved instance upon decided"
+
+	parserName = "operator"
 )
 
 type (
@@ -92,7 +94,12 @@ func (s *Service) Analyze() (Stats, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", s.logFile.Name()).
+			Error("error reading log file")
+
 		return stats, err
 	}
 

--- a/internal/analyzer/parser/operator/service.go
+++ b/internal/analyzer/parser/operator/service.go
@@ -44,7 +44,7 @@ func New(logFilePath string) (*Service, error) {
 
 func (s *Service) Analyze() (Stats, error) {
 	defer s.logFile.Close()
-	scanner := bufio.NewScanner(s.logFile)
+	scanner := parser.NewScanner(s.logFile)
 	var (
 		stats Stats = Stats{
 			Clusters: make(map[parser.SignerID][][]uint32),
@@ -94,13 +94,18 @@ func (s *Service) Analyze() (Stats, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.
-			With("err", err).
+		logger := slog.
 			With("parserName", parserName).
-			With("fileName", s.logFile.Name()).
-			Error("error reading log file")
+			With("fileName", s.logFile.Name())
+		if err == bufio.ErrTooLong {
+			logger.Warn("the log line was too long, continue reading..")
+		} else {
+			logger.
+				With("err", err).
+				Error("error reading log file")
 
-		return stats, err
+			return stats, err
+		}
 	}
 
 	stats.Clusters[stats.Owner] = clusters

--- a/internal/analyzer/parser/peers/service.go
+++ b/internal/analyzer/parser/peers/service.go
@@ -17,6 +17,8 @@ const (
 	scoredPeersMsg  = "scored peers"
 	peerIdentityMsg = "peer identity"
 	peerScoresMsg   = "peer scores"
+
+	parserName = "peers"
 )
 
 type (
@@ -108,7 +110,12 @@ func (s *Service) Analyze() (Stats, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", s.logFile.Name()).
+			Error("error reading log file")
+
 		return stats, err
 	}
 

--- a/internal/analyzer/parser/prepare/service.go
+++ b/internal/analyzer/parser/prepare/service.go
@@ -15,6 +15,8 @@ import (
 const (
 	prepareMsg       = "got prepare message"
 	leaderProposeMsg = "leader broadcasting proposal message"
+
+	parserName = "prepare"
 )
 
 type (
@@ -72,7 +74,12 @@ func (p *Service) Analyze() (map[parser.SignerID]Stats, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		slog.With("err", err).Error("error reading log file")
+		slog.
+			With("err", err).
+			With("parserName", parserName).
+			With("fileName", p.logFile.Name()).
+			Error("error reading log file")
+
 		return nil, err
 	}
 

--- a/internal/analyzer/parser/prepare/service.go
+++ b/internal/analyzer/parser/prepare/service.go
@@ -16,8 +16,7 @@ const (
 	prepareMsg       = "got prepare message"
 	leaderProposeMsg = "leader broadcasting proposal message"
 
-	parserName               = "prepare"
-	scannerBufferMaxCapacity = 1024 * 1024
+	parserName = "prepare"
 )
 
 type (

--- a/internal/analyzer/parser/scanner.go
+++ b/internal/analyzer/parser/scanner.go
@@ -1,0 +1,14 @@
+package parser
+
+import (
+	"bufio"
+	"os"
+)
+
+func NewScanner(file *os.File) *bufio.Scanner {
+	scanner := bufio.NewScanner(file)
+	const maxCapacity = 1024 * 1024
+	scanner.Buffer(make([]byte, maxCapacity), maxCapacity)
+
+	return scanner
+}


### PR DESCRIPTION
In general, a more significant refactor is needed. I believe the files should be read only once, and the log lines should be passed to all the parsers so they can identify whether it’s within their domain and extract the relevant data. At this point, it’s not causing major issues, but these changes would be easier to implement if the reader were centralized in one place