### PR TITLE
Analyzer: duplicate block root submission metric

### DIFF
--- a/internal/analyzer/cmd.go
+++ b/internal/analyzer/cmd.go
@@ -142,6 +142,9 @@ var CMD = &cobra.Command{
 					consensusAvgTotal := make(map[uint32]time.Duration)
 					consensusAvgRecordCount := make(map[uint32]uint32)
 
+					consensusDuplicateBlockRootSubmissionsPercentTotal := make(map[uint32]float32)
+					consensusDuplicateBlockRootSubmissionsPercentRecordCount := make(map[uint32]uint32)
+
 					for _, record := range records {
 						operatorStats[record.OperatorID] = report.OperatorRecord{
 							OperatorID:        record.OperatorID,
@@ -166,6 +169,9 @@ var CMD = &cobra.Command{
 
 						consensusAvgTotal[record.OperatorID] += record.ConsensusTimeAvg
 						consensusAvgRecordCount[record.OperatorID]++
+
+						consensusDuplicateBlockRootSubmissionsPercentTotal[record.OperatorID] += record.ConsensusDuplicateBlockRootSubmissionsPercent
+						consensusDuplicateBlockRootSubmissionsPercentRecordCount[record.OperatorID]++
 
 						for delay, percent := range record.CommitDelayPercent {
 							_, ok := commitDelayedPercentTotal[record.OperatorID][delay]
@@ -219,6 +225,8 @@ var CMD = &cobra.Command{
 						}
 
 						record.ConsensusTimeAvg = consensusAvgTotal[operatorID] / time.Duration(consensusAvgRecordCount[operatorID])
+						record.ConsensusDuplicateBlockRootSubmissionsPercent =
+							consensusDuplicateBlockRootSubmissionsPercentTotal[operatorID] / float32(consensusDuplicateBlockRootSubmissionsPercentRecordCount[operatorID])
 
 						operatorStats[operatorID] = record
 					}
@@ -374,6 +382,7 @@ func analyzeFile(
 			PrepareTotalCount:   r.PrepareCount,
 
 			ConsensusTimeAvg: r.ConsensusTimeAvg,
+			ConsensusDuplicateBlockRootSubmissionsPercent: r.ConsensusDuplicateBlockRootSubmissionsPercent,
 		})
 	}
 

--- a/internal/analyzer/parser/types.go
+++ b/internal/analyzer/parser/types.go
@@ -17,7 +17,9 @@ type (
 		s - slot
 		v - validator index
 	*/
-	DutyID = string
+	DutyID    = string
+	BlockRoot = string
+	Slot      = uint64
 
 	MultiFormatTime struct {
 		time.Time

--- a/internal/analyzer/report/operator.go
+++ b/internal/analyzer/report/operator.go
@@ -23,6 +23,7 @@ var operatorHeaders = []string{
 	"Prepare: \n delayed",
 	"Prepare: \n total count",
 	"Consensus: \n avg",
+	"Consensus: \n duplicate block root submissions",
 }
 
 type OperatorRecord struct {
@@ -40,7 +41,8 @@ type OperatorRecord struct {
 	PrepareDelayPercent map[time.Duration]float32
 	PrepareTotalCount   uint16
 
-	ConsensusTimeAvg time.Duration
+	ConsensusTimeAvg                              time.Duration
+	ConsensusDuplicateBlockRootSubmissionsPercent float32
 }
 
 type OperatorReport struct {
@@ -68,15 +70,17 @@ func NewOperator() *OperatorReport {
 
 func (r *OperatorReport) AddRecord(record OperatorRecord) {
 	var (
-		clusterReportItem string
-		operatorID        string = fmt.Sprint(record.OperatorID)
-		delayedPrepare    []string
-		delayedCommit     []string
+		clusterReportItem                             string
+		operatorID                                    string = fmt.Sprint(record.OperatorID)
+		consensusDuplicateBlockRootSubmissionsPercent string
+		delayedPrepare                                []string
+		delayedCommit                                 []string
 	)
 
 	if record.IsLogFileOwner {
 		operatorID = fmt.Sprintf("%d ⭐️", record.OperatorID)
 		clusterReportItem = fmt.Sprint(record.Clusters)
+		consensusDuplicateBlockRootSubmissionsPercent = fmt.Sprintf("%.2f%%", record.ConsensusDuplicateBlockRootSubmissionsPercent)
 	}
 
 	for duration, value := range record.PrepareDelayPercent {
@@ -99,6 +103,7 @@ func (r *OperatorReport) AddRecord(record OperatorRecord) {
 		strings.Join(delayedPrepare, "\n"),
 		fmt.Sprint(record.PrepareTotalCount),
 		record.ConsensusTimeAvg.String(),
+		consensusDuplicateBlockRootSubmissionsPercent,
 	)
 }
 


### PR DESCRIPTION
We’ve noticed that sometimes the leader during attestation submission provides the _old_ `block root`. This implementation checks if the same `block root` is submitted for two or more slots, calculating it as a percentage ratio.

It’s difficult to determine exactly what this indicates, but there seems to be a correlation between low attestation rates and duplicate block root submissions. This could simply be a symptom of another issue, but it seems useful to measure and visualize.

![image](https://github.com/user-attachments/assets/96f0c6a2-ebef-4f10-bf15-5221c3a85fe2)
