### PR TITLE
Post fork log support

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -26,6 +26,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: v0.1.0
           
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1

--- a/internal/analyzer/parser/operator/log.go
+++ b/internal/analyzer/parser/operator/log.go
@@ -10,6 +10,7 @@ type logEntry struct {
 	Message        string            `json:"M"`
 	PrepareSigners []parser.SignerID `json:"prepare_signers"`
 	Signers        []parser.SignerID `json:"signers"`
+	DutyID         string            `json:"duty_id"`
 }
 
 func (p *logEntry) UnmarshalJSON(data []byte) error {

--- a/internal/analyzer/parser/peers/service.go
+++ b/internal/analyzer/parser/peers/service.go
@@ -84,7 +84,7 @@ func (s *Service) Analyze() (Stats, error) {
 				slog.
 					With("err", err).
 					With("line", line).
-					Info("failed to unmarshal line. Skipping")
+					Warn("failed to unmarshal line. Skipping")
 				continue
 			}
 

--- a/internal/analyzer/parser/types.go
+++ b/internal/analyzer/parser/types.go
@@ -34,6 +34,7 @@ type (
 var customTimeLayouts = []string{
 	"2006-01-02T15:04:05.000-0700",
 	"2006-01-02T15:04:05.000Z",
+	time.RFC3339Nano,
 }
 
 func (m *MultiFormatTime) UnmarshalJSON(b []byte) error {
@@ -47,7 +48,7 @@ func (m *MultiFormatTime) UnmarshalJSON(b []byte) error {
 			m.Time = t
 			return nil
 		}
-		parseErr = err
+		parseErr = errors.Join(parseErr, err)
 	}
 
 	return errors.Join(parseErr, errors.New("unable to parse time"))

--- a/internal/analyzer/report/operator.go
+++ b/internal/analyzer/report/operator.go
@@ -52,7 +52,7 @@ type OperatorReport struct {
 func NewOperator() *OperatorReport {
 	t := table.New(os.Stdout)
 
-	t.SetHeaders("Validator Performance")
+	t.SetHeaders("Consensus Performance")
 	t.AddHeaders(operatorHeaders...)
 	t.SetAutoMerge(true)
 	t.SetHeaderColSpans(0, len(operatorHeaders))


### PR DESCRIPTION
This PR includes a fix for the Log Analyzer feature - ‘Cluster Identification.’ In post-fork logs, it is easier to identify the clusters an operator is participating in by simply parsing the dutyID.