### PR TITLE
GitHub Actions - remove hardcoded version

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -26,7 +26,6 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: 0.1.0
 
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Tested with dry run from [feature branch](https://github.com/ssvlabs/ssv-pulse/actions/runs/12008811128/job/33472231556) it seems it set the version correctly and incremented patch with minor set to `1` as expected (minor was bumped to indicate post fork support)