### PR TITLE
Alter SSV peer count health conditions

### DIFF
--- a/internal/benchmark/metric.go
+++ b/internal/benchmark/metric.go
@@ -96,8 +96,7 @@ func LoadEnabledMetrics(config configs.Config) (map[metric.Group][]metricService
 			time.Second*10,
 			[]metric.HealthCondition[uint32]{
 				{Name: ssv.PeerCountMeasurement, Threshold: 5, Operator: metric.OperatorLessThanOrEqual, Severity: metric.SeverityHigh},
-				{Name: ssv.PeerCountMeasurement, Threshold: 20, Operator: metric.OperatorLessThanOrEqual, Severity: metric.SeverityMedium},
-				{Name: ssv.PeerCountMeasurement, Threshold: 40, Operator: metric.OperatorLessThanOrEqual, Severity: metric.SeverityLow},
+				{Name: ssv.PeerCountMeasurement, Threshold: 10, Operator: metric.OperatorLessThanOrEqual, Severity: metric.SeverityMedium},
 			}))
 	}
 


### PR DESCRIPTION
5 - 10 SSV peers -> unhealthy medium severity
0 - 5 SSV peers  -> unhealthy high severity
