### PR TITLE
Benchmark: Consensus multi client support

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -5,7 +5,9 @@ benchmark:
     port: 8080
 
   consensus:
-    address: 
+  # Can be a single address or a collection of addresses. Both formats are supported:
+  # `address: http://127.0.0.1:8080` and `address: [http://127.0.0.1:8080, http://127.0.0.2:8080]`.
+    address: []
     metrics: 
       client:
         enabled: true

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `benchmark` feature allows for evaluating the health and severity of various SSV client-related metrics over time by running the application as a daemon. The addresses of the SSV client, Consensus Client, and Execution Client need to be supplied. During runtime, the benchmark will communicate with these clients through API endpoints to gather various metrics that help troubleshoot underperforming SSV clients. Additionally, it will provide infrastructure-related metrics, such as CPU and memory usage, from the environment it is running on. The metrics will be provided in an aggregated manner when the application shuts down (the `--duration` flag sets the execution time. The process can also be interrupted manually).
+The `benchmark` feature allows for evaluating the health and severity of various SSV client-related metrics over time by running the application as a daemon. The addresses of the SSV client, Consensus Client(s), and Execution Client need to be supplied. During runtime, the benchmark will communicate with these clients through API endpoints to gather various metrics that help troubleshoot underperforming SSV clients. Additionally, it will provide infrastructure-related metrics, such as CPU and memory usage, from the environment it is running on. The metrics will be provided in an aggregated manner when the application shuts down (the `--duration` flag sets the execution time. The process can also be interrupted manually).
 
 The system is designed to be flexible, allowing different metrics to have their own set of conditions that determine their health status and severity levels.
 

--- a/internal/benchmark/cmd.go
+++ b/internal/benchmark/cmd.go
@@ -96,7 +96,7 @@ var CMD = &cobra.Command{
 func addFlags(cobraCMD *cobra.Command) {
 	cobraCMD.Flags().Duration(durationFlag, defaultExecutionDuration, "Duration for which the application will run to gather metrics, e.g. '5m'")
 	cobraCMD.Flags().Uint16(serverPortFlag, defaultServerPort, "Web server port with metrics endpoint exposed, e.g. '8080'")
-	cobraCMD.Flags().String(consensusAddrFlag, "", "Consensus client address (beacon node API) with scheme (HTTP/HTTPS) and port, e.g. https://lighthouse:5052")
+	cobraCMD.Flags().String(consensusAddrFlag, "", "A comma-separated list of consensus client addresses, including the scheme (HTTP/HTTPS) and port. For example: `https://lighthouse:5052,https://prysm:5052`.")
 	cobraCMD.Flags().Bool(consensusMetricClientFlag, true, "Enable consensus client metric")
 	cobraCMD.Flags().Bool(consensusMetricLatencyFlag, true, "Enable consensus client latency metric")
 	cobraCMD.Flags().Bool(consensusMetricPeersFlag, true, "Enable consensus client peers metric")

--- a/internal/benchmark/metrics/consensus/attestation.go
+++ b/internal/benchmark/metrics/consensus/attestation.go
@@ -10,7 +10,7 @@ import (
 	client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
-	"github.com/attestantio/go-eth2-client/auto"
+	"github.com/attestantio/go-eth2-client/http"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/rs/zerolog"
 
@@ -47,15 +47,19 @@ type (
 	}
 )
 
-func NewAttestationMetric(url, name string, genesisTime time.Time, healthCondition []metric.HealthCondition[float64]) *AttestationMetric {
-	client, err := auto.New(
+func NewAttestationMetric(addr, name string, genesisTime time.Time, healthCondition []metric.HealthCondition[float64]) *AttestationMetric {
+	client, err := http.New(
 		context.TODO(),
-		auto.WithLogLevel(zerolog.DebugLevel),
-		auto.WithAddress(url),
+		http.WithLogLevel(zerolog.DebugLevel),
+		http.WithAddress(addr),
 	)
 	if err != nil {
+		slog.
+			With("addr", addr).
+			Error("failed to instantiate Consensus Client")
 		panic(err.Error())
 	}
+
 	return &AttestationMetric{
 		Base: metric.Base[float64]{
 			HealthConditions: healthCondition,


### PR DESCRIPTION
**Background**.
SSV Node will support multiple Consensus Nodes, therefore, SSV Benchmark needs to add support for this as well.

New output will look like this(3 nodes monitored):

<img width="1565" alt="Screenshot 2025-02-03 at 09 54 42" src="https://github.com/user-attachments/assets/aa11d206-9191-44b3-8198-78e8fbeec11e" />

NOTE:
There are **no** breaking changes in either flags or `config.yaml`.
