### PR TITLE
Tracks recent data points for correctness metric

### DIFF
--- a/internal/benchmark/metrics/consensus/attestation.go
+++ b/internal/benchmark/metrics/consensus/attestation.go
@@ -168,7 +168,6 @@ func (a *AttestationMetric) fetchAttestationBlockRoot(ctx context.Context, slot 
 
 func (a *AttestationMetric) AggregateResults() string {
 	var (
-		latestCorrectnessMeasurement                                                                    time.Time
 		missedAttestations, freshAttestations, missedBlocks, receivedBlocks, unreadyBlocks, correctness float64
 	)
 
@@ -178,14 +177,10 @@ func (a *AttestationMetric) AggregateResults() string {
 		freshAttestations += point.Values[FreshAttestationMeasurement]
 		receivedBlocks += point.Values[ReceivedBlockMeasurement]
 		unreadyBlocks += point.Values[UnreadyBlockMeasurement]
+	}
 
-		val, ok := point.Values[CorrectnessMeasurement]
-		if ok {
-			if latestCorrectnessMeasurement.Before(point.Timestamp) {
-				correctness = val
-				latestCorrectnessMeasurement = point.Timestamp
-			}
-		}
+	if receivedBlocks > 0 {
+		correctness = freshAttestations / receivedBlocks * 100
 	}
 
 	return fmt.Sprintf(

--- a/internal/benchmark/metrics/consensus/attestation.go
+++ b/internal/benchmark/metrics/consensus/attestation.go
@@ -26,6 +26,7 @@ const (
 	MissedAttestationMeasurement = "MissedAttestation"
 	FreshAttestationMeasurement  = "FreshAttestation"
 	CorrectnessMeasurement       = "Correctness"
+	recentDataPointsWindow       = 32
 )
 
 var (
@@ -260,8 +261,8 @@ func (a *AttestationMetric) AddDataPoint(values map[string]float64) {
 		Timestamp: time.Now(),
 		Values:    values,
 	})
-	if len(a.recentDataPoints) > 32 {
-		a.recentDataPoints = a.recentDataPoints[len(a.recentDataPoints)-32:]
+	if len(a.recentDataPoints) > recentDataPointsWindow {
+		a.recentDataPoints = a.recentDataPoints[len(a.recentDataPoints)-recentDataPointsWindow:]
 	}
 }
 


### PR DESCRIPTION
Minimally invasive change so that correctness over Prometheus is exposed over the last epoch instead of historically; otherwise, pods running with a pulse as a sidecar turn this metric into something that is less valuable over time.

`WriteMetric` will also use this calculated correctness which in my opinion is fine.

Addressing the ever-growing memory and a different way of structuring all datapoints can maybe be left for another PR. 