### PR TITLE
ci: harden pipeline — timeouts, release serialization, coverage summary

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
   docker:
     name: Build/Push Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write
       packages: write
@@ -37,6 +38,8 @@ jobs:
       IMAGE_TAG: ${{ inputs.image-tag }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,25 +2,22 @@ name: Go checks
 
 on:
   workflow_call:
-    inputs:
-      go-version:
-        description: Go version to set up
-        required: false
-        type: string
-        default: "1.26"
 
 jobs:
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: |
             go.sum
@@ -32,14 +29,17 @@ jobs:
   go-build:
     name: Go Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Build
@@ -48,15 +48,25 @@ jobs:
   go-test:
     name: Go Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Test
-        run: make test
+        run: make test_coverage
+
+      - name: Coverage summary
+        run: |
+          echo '### Test coverage' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          go tool cover -func=coverage.out | tail -n 1 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow-feature.yml
+++ b/.github/workflows/workflow-feature.yml
@@ -1,15 +1,13 @@
 name: Feature branch workflow
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - main
 
+# Rapid successive pushes to a PR cancel the outdated in-flight run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Serialize release runs so two quick merges cannot race the tag bump.
+concurrency:
+  group: main-release
+  cancel-in-progress: false
+
 env:
   IMAGE_ARCHITECTURES: linux/amd64,linux/arm64
   IMAGE_REGISTRY: ghcr.io
@@ -21,6 +26,7 @@ jobs:
   publish-release:
     name: Publish Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: go-checks
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test:
 
 .PHONY: test_coverage
 test_coverage:
-	go test ./... -coverprofile=coverage.out
+	go test -race ./... -coverprofile=coverage.out
 
 .PHONY: dep
 dep:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################
-FROM --platform=$BUILDPLATFORM golang:1.24@sha256:10c131810f80a4802c49cab0961bbe18a16f4bb2fb99ef16deaa23e4246fc817 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:ae5a2316d12f3e78fd99177dad452e6ad4f240af2d71d57b480c3477f250fec6 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ssvlabs/ssv-pulse
 
-go 1.24
+go 1.26
 
 require (
 	github.com/aquasecurity/table v1.10.0


### PR DESCRIPTION
## Summary

Follow-up to #114. Hardens the CI pipeline against hangs, release races, and version drift, and makes test coverage visible per run.

## Changes

**Go version — single source of truth**
- `setup-go` now reads `go-version-file: go.mod` instead of a hardcoded `1.26` input default
- `go.mod` floor raised `1.24` → `1.26` — the effective floor was already 1.26 (`tool.mod` requires it, CI already ran it); this declares it honestly

**Resilience**
- `timeout-minutes` on every job (10 for go jobs and release, 20 for docker) — a hung `-race` test would otherwise burn GitHub's 6-hour default and block releases via the `needs:` chain
- `concurrency: main-release` (no cancel-in-progress) on `workflow-main.yml` — two quick merges to main can no longer run `publish-release` concurrently and race the tag bump

**Hardening**
- `persist-credentials: false` on checkouts in `go.yml` and `docker.yml` — these jobs never push, so they shouldn't keep the token in `.git/config`

**Deduplicated PR checks**
- feature workflow now triggers on `pull_request` only — the `push` trigger duplicated every run on branches with an open PR, and the immediately-cancelled duplicate rendered as failed checks; PR runs also test the merge commit against current main, the stronger signal. Branches without a PR get no CI, which is moot since rulesets require a PR to merge.

**Docker**
- builder image bumped `golang:1.24` → `golang:1.26` (SHA-pinned) — the official golang images set `GOTOOLCHAIN=local`, so the old builder fails hard on the raised `go.mod` floor

**Coverage visibility**
- CI test job runs `make test_coverage` (now with `-race`, matching `make test`) and appends the total to the job summary — currently **10.6%** (counts all packages, including those without tests)

## Testing

`make build`, `make test`, and `make test_coverage` all pass locally under native Go 1.26 (the exact toolchain CI will now install). Coverage summary line verified against the generated profile.

## Breaking changes

Local development now requires **Go ≥ 1.26**. Running an older `go` binary triggers toolchain auto-switching, which has a Go defect that breaks `-race -cover` builds (`compile: version "go1.26.0" does not match go tool version …`) — update your install from https://go.dev/dl rather than relying on the auto-switch.

## Note for repo admins

Merges to main are still not gated on CI: neither the classic branch protection nor the ssvlabs rulesets require any status checks, so the #114 gate is advisory. Requiring `go-checks / Go Lint`, `go-checks / Go Build`, `go-checks / Go Test` in the ruleset is an org-admin settings change that would close this.
