### PR TITLE
ci: replace mathieudutour/github-tag-action with anothrNick/github-tag-action

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -30,21 +30,29 @@ jobs:
     needs: go-checks
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: '0'
 
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          TAG_PREFIX: v
+          RELEASE_BRANCHES: main
+          DEFAULT_BRANCH: main
 
       - name: Create a GitHub release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          generateReleaseNotes: true
 
   docker-build-push:
     uses: ./.github/workflows/docker.yml


### PR DESCRIPTION
## Why

Follow-up to #113. `mathieudutour/github-tag-action` has had no release since v6.2 (March 2024), still targets Node 20, and there's no newer version to pin to upstream — it's abandoned.

## What changed

Checked this repo's actual tag history before picking a replacement: 84 of 85 releases (`v0.0.1` → `v0.1.47`) were plain patch bumps — only one was ever a minor bump. The Conventional-Commits-aware semver detection `mathieudutour/github-tag-action` nominally provides isn't actually driving anything here in practice; every merge to `main` just gets a patch release regardless of content.

Given that, replaced it with `anothrNick/github-tag-action`, configured with `DEFAULT_BUMP: patch` to match the existing behavior exactly:
- It's a **Docker action**, not a Node action — verified via its `action.yml` (`using: 'docker'`) — so it's not exposed to this whole class of Node-runtime-deprecation problem going forward.
- Actively maintained (commits as recent as August 2025, vs. mathieudutour's June 2024).
- Pinned to a commit SHA per this repo's existing convention.

Also considered `go-semantic-release/action` first, but its own `action.yml` still declares `using: 'node20'` — the *semantic-release engine* is Go, but the Action wrapper itself is a JS action, so it wouldn't actually solve the underlying problem, and it's similarly stale (last commit Jan 2025).

Side effect: `anothrNick/github-tag-action` doesn't produce a changelog output, so `ncipollo/release-action`'s body now uses `generateReleaseNotes: true` (GitHub-native, generated from merged PRs) instead of a piped-in changelog string.

## Testing

This logic only runs on `push` to `main`, so it can't be exercised by this PR's own CI. I verified locally against this repo's real git state that the tag-detection regex/sort correctly finds `v0.1.47` as latest, and that merging this PR (which creates a new commit distinct from the `v0.1.47` commit) will correctly trigger a real `v0.1.48` bump rather than a false skip — i.e. merging this PR is the first live exercise of the new logic. Worth watching the first `Main branch workflow` run after merge to confirm the release gets published as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)