### PR TITLE
ci: manual dev-release via workflow_dispatch in the feature workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: linux/amd64,linux/arm64
+      tag-latest:
+        description: "also tag the image as ':latest'. Defaults to 'true'."
+        required: false
+        type: boolean
+        default: true
 
 env:  
   IMAGE_REGISTRY: ghcr.io
@@ -60,8 +65,9 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }}
           push: ${{ inputs.with-push }}
           platforms: ${{ inputs.image-architectures }}
+          # Second line is empty when tag-latest is false; blank tag lines are ignored.
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ github.repository }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_REGISTRY }}/${{ github.repository }}:latest
+            ${{ inputs.tag-latest && format('{0}/{1}:latest', env.IMAGE_REGISTRY, github.repository) || '' }}
           outputs: |
             type=image,name=target,annotation-index.org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}

--- a/.github/workflows/workflow-feature.yml
+++ b/.github/workflows/workflow-feature.yml
@@ -4,10 +4,17 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Dev image tag to push. Defaults to the commit SHA."
+        required: false
+        type: string
+        default: ""
 
-# Rapid successive pushes to a PR cancel the outdated in-flight run.
+# A newer run for the same branch cancels the outdated in-flight one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +24,7 @@ jobs:
       contents: read
 
   docker-build:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/docker.yml
     needs: go-checks
     permissions:
@@ -25,4 +33,18 @@ jobs:
       contents: read
     with:
       with-push: false
+      image-architectures: linux/amd64
+
+  docker-build-push:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/docker.yml
+    needs: go-checks
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    with:
+      with-push: true
+      tag-latest: false
+      image-tag: ${{ inputs.tag != '' && inputs.tag || github.sha }}
       image-architectures: linux/amd64


### PR DESCRIPTION
## What

Lets any branch be built and pushed to ghcr **on demand** (for semi-manual deployment), folded into the existing feature workflow rather than a new file.

Run it from the Actions tab → "Feature branch workflow" → "Run workflow" → pick a branch.

## Approach

GitHub can't dispatch an individual job — the unit of triggering is a whole workflow. But a single file can carry two triggers and gate jobs per-event with `if:`, which gives the same result with no extra file:

- `pull_request` → `docker-build` (build only, no push) — **unchanged behavior**
- `workflow_dispatch` → `docker-build-push` (build + push)

## Tagging

- Default tag is the **commit SHA** (`${{ github.sha }}`) — immutable, unique, already a valid Docker tag, so no sanitization step/extra job is needed. Optional custom `tag` input if you want to name it.
- **Never touches `:latest`** — `docker.yml` gains a `tag-latest` input (default `true`); the push path sets it `false`. Release/PR paths omit it and keep existing behavior byte-for-byte.

## For context — how releases are tagged today

On push to `main`: semver git tag `vX.Y.Z` → image pushed as `:vX.Y.Z` **+** `:latest`. No SHA tag. Feature branches previously only *built* (no push) — this fills that gap.

## Changes

- `workflow-feature.yml` (+26/-2): added `workflow_dispatch` (+ optional `tag` input); gated `docker-build` to PRs and added a dispatch-only `docker-build-push` job.
- `docker.yml` (+8/-1): added `tag-latest` input.

## Notes / decisions

- **`go-checks` gate:** pushed images pass the same build/lint/test bar as a PR first (`docker-build-push` `needs: go-checks`). Say the word if you'd rather allow pushing WIP that doesn't pass — I'd add a skip toggle.
- **Availability:** `workflow_dispatch` is usable once this reaches `main`, and the dispatched branch must contain these workflow files (branched from / rebased onto `main`).
- Default tag is the full commit SHA rather than `<branch>-<sha>` specifically to avoid a shell sanitization step (GHA expressions can't string-replace the `/` in branch names). If you'd prefer `<branch>-<sha>`, that's a small `metadata-action` or shell-step add — flag me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)