### PR TITLE
ci: multi-arch dev images + dev- tag prefix

### DIFF
--- a/.github/workflows/workflow-feature.yml
+++ b/.github/workflows/workflow-feature.yml
@@ -46,5 +46,4 @@ jobs:
     with:
       with-push: true
       tag-latest: false
-      image-tag: ${{ inputs.tag != '' && inputs.tag || github.sha }}
-      image-architectures: linux/amd64
+      image-tag: ${{ inputs.tag != '' && inputs.tag || format('dev-{0}', github.sha) }}


### PR DESCRIPTION
Follow-ups to the manual dev-release job added in #123.

## Changes

- **Multi-arch dev images.** The pushed dev image now builds `linux/amd64` **and** `linux/arm64`, matching the release path. It was amd-only only because that line was inherited from the PR build-check job (where single-arch is intentional — that job just validates the build and pushes nothing, so building arm under emulation would double PR CI time for no benefit). A deployable dev image has no reason to be restricted. Done by dropping `image-architectures` so `docker.yml`'s default (`linux/amd64,linux/arm64`) applies — exactly how the `main` workflow's `docker-build-push` gets multi-arch.
- **`dev-` tag prefix.** Default dev tag is now `dev-<sha>` instead of a bare `<sha>`, so it's self-evidently a non-release build. Follows the prefix convention used by `docker/metadata-action` (`sha-`, `pr-`). The custom `tag` input still overrides it.

## Tag convention notes

No single mandated standard exists; the recognized signals are SemVer pre-release suffixes (`-dev`/`-rc`/`-alpha`, needs a version base), moving channel words (`edge`/`nightly`/`dev`), or prefixed immutable tags (`sha-`/`pr-`). For an immutable per-commit deployable image, a `dev-` prefix on the SHA is the cleanest fit: explicit, reproducible, and groups dev tags together in ghcr.

- Prefix (`dev-<sha>`) chosen over suffix (`<sha>-dev`) as the more common marker style; trivial to flip if you prefer the suffix.
- Full SHA (not short) keeps it inline — GHA expressions can't shorten a SHA without a shell step. If you'd rather have `dev-<short-sha>`, that's a small step/job add.

The whole change is 2 lines in `workflow-feature.yml`; `docker.yml` is untouched. Left as **draft** for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)